### PR TITLE
feat: Implement initial shipment status feature

### DIFF
--- a/Model/QueryHandler.php
+++ b/Model/QueryHandler.php
@@ -39,13 +39,15 @@ class QueryHandler
         $loggedIn = $session ? true : false;
 
         // If user-specific query and not logged in, request login
-        if (!$loggedIn && in_array($queryType, ['order_status', 'refund_status'])) {
+        if (!$loggedIn && in_array($queryType, ['order_status', 'refund_status', 'shipment_status'])) {
             return ['error' => 'Please log in to access this information.'];
         }
 
         // User-Specific Queries
         if ($queryType == 'order_status') {
             return $this->fetchOrderStatus($queryData['order_id']);
+        } elseif ($queryType == 'shipment_status') {
+            return $this->fetchShipmentStatus($queryData['order_id']);
         }
 
         // Call AI Chatbot Service for General Queries
@@ -61,6 +63,14 @@ class QueryHandler
         return $order->getId()
             ? ['order_id' => $orderId, 'status' => $order->getStatus()]
             : ['error' => 'Order not found'];
+    }
+
+    /**
+     * Fetch shipment status
+     */
+    protected function fetchShipmentStatus($orderId)
+    {
+        return ['order_id' => $orderId, 'shipment_status' => 'Shipped', 'tracking_number' => '12345XYZ'];
     }
 
     /**

--- a/chatbot_server.py
+++ b/chatbot_server.py
@@ -20,6 +20,8 @@ def handle_query():
 
     if user_logged_in and data.get("query_type") == "order_status":
         return jsonify({"response": f"Your order {data['order_id']} is in processing."})
+    if user_logged_in and data.get("query_type") == "shipment_status":
+        return jsonify({"response": f"Shipment for order {data['order_id']} is currently being processed."})
 
     # Fetch response from ChromaDB
     documents = retriever.similarity_search(query, k=3)


### PR DESCRIPTION
This commit introduces the initial implementation for querying shipment status via the chatbot.

Changes include:
- Modified `Model/QueryHandler.php`:
    - Added `shipment_status` to the list of query types requiring user login.
    - Implemented a new `fetchShipmentStatus(\$orderId)` method that currently returns mock shipment data (e.g., status 'Shipped', tracking number '12345XYZ').
    - Updated `handleQuery` to route `shipment_status` queries to the new method.
- Modified `chatbot_server.py`:
    - Added a handler for `shipment_status` queries when a user is logged in, returning a placeholder response indicating the shipment is being processed.

Note: Unit tests for this feature were not added as there is no existing test infrastructure in the project. This can be addressed in a future update.